### PR TITLE
Keep the standard behavior, use standard input

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "tests"
   ],
   "dependencies": {
-    "datetimepicker": "~2.4.1",
-    "angular": "~1.3.13"
+    "datetimepicker": "~2.4.5",
+    "angular": "^1.3.15",
   }
 }

--- a/datetimepicker.js
+++ b/datetimepicker.js
@@ -1,127 +1,131 @@
-var datetimepicker = angular.module('xdan.datetimepicker', []);
+angular.module('xdan.datetimepicker', [
 
-datetimepicker.directive('xdanDatetimepicker', function() {
-    return {
-        require: '?ngModel',
-        scope: {
-            user_options: '=xdanDatetimepicker',
-            picker_type_option: '@pickerType',
-            view_format_option: '@viewFormat',
-            model_format_option: '@modelFormat'
-        },
-        template: '<input type="text">',
-        link: function(scope, element, attrs, ngModelController) {
-            // The most famous date format in my country ;)
-            var DEFAULT_VIEW_DATE_FORMAT = 'd-m-Y',
-                DEFAULT_VIEW_TIME_FORMAT = 'H:i',
-                DEFAULT_VIEW_FORMAT = DEFAULT_VIEW_DATE_FORMAT + ' ' + DEFAULT_VIEW_TIME_FORMAT,
+])
+.directive('xdanDatetimepicker', function() {
+  'use strict';
+  return {
+    require: '?ngModel',
+    scope: {
+      user_options: '=xdanDatetimepicker',
+      picker_type_option: '@pickerType',
+      view_format_option: '@viewFormat',
+      model_format_option: '@modelFormat'
+    },
+    // template: '<input type="text">',
+    link: function(scope, element, attrs, ngModelController) {
+      // The most famous date format in my country ;)
+      var DEFAULT_VIEW_DATE_FORMAT = 'd-m-Y',
+        DEFAULT_VIEW_TIME_FORMAT = 'H:i',
+        DEFAULT_VIEW_FORMAT = DEFAULT_VIEW_DATE_FORMAT + ' ' + DEFAULT_VIEW_TIME_FORMAT,
 
-                DEFAULT_MODEL_DATE_FORMAT = 'Y-m-d',
-                DEFAULT_MODEL_TIME_FORMAT= 'H:i:s',
-                DEFAULT_MODEL_FORMAT = DEFAULT_MODEL_DATE_FORMAT + ' ' + DEFAULT_MODEL_TIME_FORMAT;
+        DEFAULT_MODEL_DATE_FORMAT = 'Y-m-d',
+        DEFAULT_MODEL_TIME_FORMAT = 'H:i:s',
+        DEFAULT_MODEL_FORMAT = DEFAULT_MODEL_DATE_FORMAT + ' ' + DEFAULT_MODEL_TIME_FORMAT;
 
-            if (scope.picker_type_option) {
-                scope.picker_type = scope.picker_type_option;
-            } else {
-                scope.picker_type = 'datetime';
-            }
+      if (scope.picker_type_option) {
+        scope.picker_type = scope.picker_type_option;
+      } else {
+        scope.picker_type = 'datetime';
+      }
 
-            if (scope.view_format_option) {
-                scope.view_format = scope.view_format_option;
-            } else {
-                if (scope.picker_type == 'date') {
-                    scope.view_format = DEFAULT_VIEW_DATE_FORMAT;
-                } else if (scope.picker_type == 'time') {
-                    scope.view_format = DEFAULT_VIEW_TIME_FORMAT;
-                } else {
-                    scope.view_format = DEFAULT_VIEW_FORMAT;
-                }
-                
-            }
-
-            if (scope.model_format_option && scope.picker_type == 'datetime') {
-                scope.model_format = scope.model_format_option;
-            } else {
-                if (scope.picker_type == 'date') {
-                    scope.model_format = DEFAULT_MODEL_DATE_FORMAT;
-                } else if (scope.picker_type == 'time') {
-                    scope.model_format = DEFAULT_MODEL_TIME_FORMAT;
-                } else {
-                    scope.model_format = DEFAULT_MODEL_FORMAT;
-                }
-                
-            }
-
-            // default options
-            // I hate scrollMonth!!!
-            scope.options = {
-                scrollMonth: false,
-                format: scope.view_format
-            };
-            
-            if (scope.user_options) {
-                angular.extend(scope.options, scope.user_options);
-            }
-
-            // last override!
-            if (scope.picker_type == 'date') {
-                scope.options.datepicker = true;
-                scope.options.timepicker = false;
-            } else if (scope.picker_type == 'time') {
-                scope.options.datepicker = false;
-                scope.options.timepicker = true;
-            } else if (scope.picker_type == 'datetime') {
-                scope.options.datepicker = true;
-                scope.options.timepicker = true;
-            }
-
-            if (scope.user_options.onChangeDateTime) {
-                scope.options.onChangeDateTime = function(current_time, input) {
-                    scope.user_options.onChangeDateTime();
-                    if (ngModelController) {
-                        if (scope.picker_type == 'datetime') {
-                            ngModelController.$setViewValue(current_time);
-                        } else {
-                            ngModelController.$setViewValue(current_time.dateFormat(scope.model_format));
-                        }
-                    }
-                };
-            } else {
-                scope.options.onChangeDateTime = function(current_time, input) {
-                    if (ngModelController) {
-                        if (scope.picker_type != 'datetime') {
-                            ngModelController.$setViewValue(current_time.dateFormat(scope.model_format));
-                        } else {
-                            ngModelController.$setViewValue(current_time);
-                        }
-                    }
-                }
-            }
-
-            if (ngModelController) {
-                ngModelController.$render = function() {
-                    element.find('input[type=text]').datetimepicker(scope.options);
-                };
-
-                ngModelController.$formatters.push(function(modelValue) {
-                    var date;
-                    // todo: parse date/time/datetime
-                    if (modelValue) {
-                        if (scope.picker_type == 'date') {
-                            date = new Date(modelValue + ' 00:00:00');
-                        } else if (scope.picker_type == 'time') {
-                            date = new Date('1970-01-01 ' + modelValue);
-                        } else {
-                            date = new Date(modelValue);
-                        }
-
-                        date = date.dateFormat(scope.options.format);
-                        element.find('input[type=text]').val(date);
-                    }
-
-                    return modelValue
-                });
-            }
+      if (scope.view_format_option) {
+        scope.view_format = scope.view_format_option;
+      } else {
+        if (scope.picker_type === 'date') {
+          scope.view_format = DEFAULT_VIEW_DATE_FORMAT;
+        } else if (scope.picker_type === 'time') {
+          scope.view_format = DEFAULT_VIEW_TIME_FORMAT;
+        } else {
+          scope.view_format = DEFAULT_VIEW_FORMAT;
         }
+
+      }
+
+      if (scope.model_format_option && scope.picker_type === 'datetime') {
+        scope.model_format = scope.model_format_option;
+      } else {
+        if (scope.picker_type === 'date') {
+          scope.model_format = DEFAULT_MODEL_DATE_FORMAT;
+        } else if (scope.picker_type === 'time') {
+          scope.model_format = DEFAULT_MODEL_TIME_FORMAT;
+        } else {
+          scope.model_format = DEFAULT_MODEL_FORMAT;
+        }
+
+      }
+
+      // default options
+      // I hate scrollMonth!!!
+      scope.options = {
+        scrollMonth: false,
+        format: scope.view_format
+      };
+
+      if (scope.user_options) {
+        angular.extend(scope.options, scope.user_options);
+      }
+
+      // last override!
+      if (scope.picker_type === 'date') {
+        scope.options.datepicker = true;
+        scope.options.timepicker = false;
+      } else if (scope.picker_type === 'time') {
+        scope.options.datepicker = false;
+        scope.options.timepicker = true;
+      } else if (scope.picker_type === 'datetime') {
+        scope.options.datepicker = true;
+        scope.options.timepicker = true;
+      }
+
+      if (scope.user_options.onChangeDateTime) {
+        scope.options.onChangeDateTime = function(current_time) {
+          scope.user_options.onChangeDateTime();
+          if (ngModelController) {
+            if (scope.picker_type === 'datetime') {
+              ngModelController.$setViewValue(current_time);
+            } else {
+              ngModelController.$setViewValue(current_time.dateFormat(scope.model_format));
+            }
+          }
+        };
+      } else {
+        scope.options.onChangeDateTime = function(current_time) {
+          if (ngModelController) {
+            if (scope.picker_type !== 'datetime') {
+              ngModelController.$setViewValue(current_time.dateFormat(scope.model_format));
+            } else {
+              ngModelController.$setViewValue(current_time);
+            }
+          }
+        };
+      }
+
+      if (ngModelController) {
+        ngModelController.$render = function() {
+          // element.find('input[type=text]').datetimepicker(scope.options);
+          element.datetimepicker(scope.options);
+        };
+
+        ngModelController.$formatters.push(function(modelValue) {
+          var date;
+          // todo: parse date/time/datetime
+          if (modelValue) {
+            if (scope.picker_type === 'date') {
+              date = new Date(modelValue + ' 00:00:00');
+            } else if (scope.picker_type === 'time') {
+              date = new Date('1970-01-01 ' + modelValue);
+            } else {
+              date = new Date(modelValue);
+            }
+
+            date = date.dateFormat(scope.options.format);
+            // element.find('input[type=text]').val(date);
+            element.val(date);
+          }
+
+          return modelValue;
+        });
+      }
     }
+  };
 });

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <div id="webpage" data-ng-controller="MyController">
     <h1>Angular Directive for Xdan's Datetimepicker</h1>
 
-    <span data-xdan-datetimepicker="{timepicker:false}" data-ng-model="the_date"></span>
+    <input type="text" data-xdan-datetimepicker="{timepicker:false}" data-ng-model="the_date"></input>
     {{ the_date }}
 </div>
 


### PR DESCRIPTION
Hi, 

The nested template is not going to work well. 
Please let the directive just use the host element as the xdan library does.

I removed the template from the directive and modified the code to use whatever element is attached to. :)

This way developers can do:

``` js
  <input 
    type="text" 
    class="form-control" 
    data-xdan-datetimepicker="{
              timepicker: false,
              dayOfWeekStart: 1,
              lang: 'en',
              format: 'Y-m-d H:i'
            }" 
     data-ng-model="yourModel"></input>
```
